### PR TITLE
Recursive rules support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,37 @@ var_dump($evaluation->getHistory()[0]->getRule()::class); // string(5) "RuleA"
 var_dump($evaluation->getHistory()[1]->getRule()::class); // string(5) "RuleB"
 ```
 
+### Recursive usage
+
+You might pass rules and array of rules to recursively evaluate them.
+
+> Note: A future version of this library might come with Openswoole support to parallelize the evaluation of each subset of rules.
+
+```php
+use SimpleRulesEngine\Evaluation;
+use SimpleRulesEngine\RulesEngine;
+
+
+$rules = [
+    new ARule(), // 0
+    new BRule(), // 1
+    [
+        new AARule(), // 2
+        [
+            new AAARule(), // 3
+            new AABRule(), // 4
+            new AACRule(), // 5
+        ]
+    ],
+    new CRule() // 6
+];
+
+$evaluation = RulesEngine::run(
+    subject: '...',
+    rules: $rules
+);
+```
+
 ## Examples
 
 The examples are very simple for demo purposes, but they show the basic features this package comes with.

--- a/src/RulesEngine.php
+++ b/src/RulesEngine.php
@@ -7,16 +7,52 @@ use InvalidArgumentException;
 class RulesEngine
 {
     /**
-     * @param Rule[] $rules
+     * @param Rule|array<Rule|Rule[]> $rules
      */
-    public static function run(mixed $subject, array $rules, bool $withHistory = false): ?Evaluation
+    public static function run(mixed $subject, array|Rule $rules, bool $withHistory = false): ?Evaluation
+    {
+        $evaluation = self::runRecursively($subject, $rules, $withHistory);
+
+        if ($evaluation instanceof Evaluation && $withHistory) {
+            $history = $evaluation->getHistory();
+            array_pop($history);
+            $evaluation->setHistory($history);
+        }
+
+        return $evaluation;
+    }
+
+    /**
+     * @param Rule|array<Rule|Rule[]> $rules
+     */
+    protected static function runRecursively(mixed $subject, array|Rule $rules, bool $withHistory = false): ?Evaluation
     {
         $evaluation = null;
         $previousEvaluation = null;
         /** @var Evaluation[] $history */
         $history = [];
 
-        foreach ($rules as $i => $rule) {
+        if ($rules instanceof Rule) {
+            $rules = [$rules];
+        }
+
+        foreach ($rules as $rule) {
+            if ($evaluation?->shouldStop()) {
+                break;
+            }
+
+            /** @var Rule|array<Rule|Rule[]> $rule */
+            if (is_array($rule)) {
+                $evaluation = self::runRecursively($subject, $rule, $withHistory);
+
+                if ($evaluation instanceof Evaluation && $withHistory) {
+                    $history = array_merge($history, $evaluation->getHistory());
+                    $evaluation->setHistory([]);
+                }
+
+                continue;
+            }
+
             if (!$rule instanceof Rule) {
                 throw new InvalidArgumentException(sprintf(
                     '"%s" should be an instance of %s',
@@ -32,16 +68,12 @@ class RulesEngine
             $evaluation = $rule->evaluate($subject, $previousEvaluation);
             $evaluation->setRule($rule);
 
-            if ($i > 0 && $withHistory && $previousEvaluation instanceof Evaluation) {
-                $history[] = $previousEvaluation;
-            }
-
-            if ($evaluation->shouldStop()) {
-                break;
-            }
+            $history[] = $evaluation;
         }
 
-        $evaluation?->setHistory($history);
+        if ($evaluation instanceof Evaluation && $withHistory) {
+            $evaluation->setHistory($history);
+        }
 
         return $evaluation;
     }


### PR DESCRIPTION
Note: A future version of this library might come with Openswoole support to parallelize the evaluation of each subset of rules.
